### PR TITLE
Adding set_index_parameter and set_index_parameters to increase accuracy

### DIFF
--- a/distributed_faiss/client.py
+++ b/distributed_faiss/client.py
@@ -201,6 +201,11 @@ class IndexClient:
         return self.pool.imap(
             lambda idx: idx.set_index_parameter(index_id, param, value), self.sub_indexes
         )
+    
+    def set_index_parameters(self, index_id: str, str_param: str):
+        return self.pool.imap(
+            lambda idx: idx.set_index_parameters(index_id, str_param), self.sub_indexes
+        )
 
     def search(
         self, query, topk: int, index_id: str, return_embeddings: bool = False

--- a/distributed_faiss/client.py
+++ b/distributed_faiss/client.py
@@ -197,6 +197,11 @@ class IndexClient:
     def async_train(self, index_id: str):
         self.pool.map(lambda idx: idx.sync_train(index_id), self.sub_indexes)
 
+    def set_index_parameter(self, index_id: str, param: str, value: int):
+        self.pool.imap(
+            lambda idx: idx.set_index_parameter(index_id, param, value), self.sub_indexes
+        )
+
     def search(
         self, query, topk: int, index_id: str, return_embeddings: bool = False
     ) -> Tuple[np.ndarray, List]:

--- a/distributed_faiss/client.py
+++ b/distributed_faiss/client.py
@@ -198,7 +198,7 @@ class IndexClient:
         self.pool.map(lambda idx: idx.sync_train(index_id), self.sub_indexes)
 
     def set_index_parameter(self, index_id: str, param: str, value: int):
-        self.pool.imap(
+        return self.pool.imap(
             lambda idx: idx.set_index_parameter(index_id, param, value), self.sub_indexes
         )
 

--- a/distributed_faiss/index.py
+++ b/distributed_faiss/index.py
@@ -237,6 +237,9 @@ class Index:
             # client's batches go to different server nodes without waiting for add_buffer_to_index completion
             _thread.start_new_thread(self._add_buffer_to_idx, ())
 
+    def set_index_parameter(self, param: str, value: int):
+        faiss.ParameterSpace().set_index_parameter(self.faiss_index, param, value)
+
     # TODO: overload to get faiss indexes back, not metadata
     def search(
         self, query_batch: np.array, top_k: int = 100, return_embeddings: bool = False

--- a/distributed_faiss/index.py
+++ b/distributed_faiss/index.py
@@ -241,6 +241,11 @@ class Index:
         with self.index_lock:
             if self.faiss_index:
                 faiss.ParameterSpace().set_index_parameter(self.faiss_index, param, value)
+
+    def set_index_parameters(self, str_param: int):
+        with self.index_lock:
+            if self.faiss_index:
+                faiss.ParameterSpace().set_index_parameters(self.faiss_index, str_param)
         
 
     # TODO: overload to get faiss indexes back, not metadata

--- a/distributed_faiss/index.py
+++ b/distributed_faiss/index.py
@@ -238,7 +238,10 @@ class Index:
             _thread.start_new_thread(self._add_buffer_to_idx, ())
 
     def set_index_parameter(self, param: str, value: int):
-        faiss.ParameterSpace().set_index_parameter(self.faiss_index, param, value)
+        with self.index_lock:
+            if self.faiss_index:
+                faiss.ParameterSpace().set_index_parameter(self.faiss_index, param, value)
+        
 
     # TODO: overload to get faiss indexes back, not metadata
     def search(

--- a/distributed_faiss/server.py
+++ b/distributed_faiss/server.py
@@ -317,6 +317,11 @@ class IndexServer:
         t = IndexTrainer(self)
         t.run()
 
+    def set_index_parameter(self, index_id: str, param: str, value: int):
+        logger.info(f"Setting param={param} with value={value}")
+        index = self._get_index(index_id)
+        return index.set_index_parameter(param, value)
+
     def search(
         self, index_id: str, query_batch: np.array, top_k: int, return_embeddings: bool
     ) -> Tuple:

--- a/distributed_faiss/server.py
+++ b/distributed_faiss/server.py
@@ -321,6 +321,11 @@ class IndexServer:
         logger.info(f"Setting param={param} with value={value}")
         index = self._get_index(index_id)
         return index.set_index_parameter(param, value)
+    
+    def set_index_parameters(self, index_id: str, str_param: int):
+        logger.info(f"Setting str_param={str_param}")
+        index = self._get_index(index_id)
+        return index.set_index_parameters(str_param)
 
     def search(
         self, index_id: str, query_batch: np.array, top_k: int, return_embeddings: bool


### PR DESCRIPTION
Adding `set_index_parameter` function to set any parameter on all indexes in the cluster.

**What was missing:**
A function to add parameters to indexes outside of nprobe (for example: efSearch, k_factor_rf, ...) to perform more precise searches

**What is added:**
set_index_parameter function callable via `faiss_client.set_index_parameter(INDEX_ID, "parameter", value)` which adds the parameter with the corresponding value to all the indexes of the cluster via `faiss.ParameterSpace().set_index_parameter(...)`.